### PR TITLE
source the rm toolchain in pipelines

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -63,9 +63,12 @@ jobs:
 
             export QT_SELECT=qt6
 
+
+        # Source the rm toolchain ". /opt/codex/*/*/environment-setup-*"
+        # Then run, ./make.sh from the appload install script
         - name: Build Application
           run: |
-            chmod a+x ./make.sh
+            . /opt/codex/*/*/environment-setup-*
             ./make.sh
           working-directory: ./xovi
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -63,12 +63,12 @@ jobs:
 
             export QT_SELECT=qt6
 
-
         # Source the rm toolchain ". /opt/codex/*/*/environment-setup-*"
         # Then run, ./make.sh from the appload install script
         - name: Build Application
           run: |
             . /opt/codex/*/*/environment-setup-*
+            chmod a+x ./make.sh
             ./make.sh
           working-directory: ./xovi
 


### PR DESCRIPTION
Added `. /opt/codex/*/*/environment-setup-*` to the pipeline right before the make script to "source the rm toolchain".
This made the size of the `.so` significantly bigger and the 2 download artifacts are now of different size.

Also, tested the output on my `rmPP` and the appload icon shows up now.