### PR TITLE
Update appload.qmd for 3.19

### DIFF
--- a/xovi/appload.qmd
+++ b/xovi/appload.qmd
@@ -2,7 +2,7 @@ AFFECT [[8850026134298937527]]
     IMPORT net.asivery.AppLoad 1.0
     IMPORT xofm.libs.gestures 1.0
     TRAVERSE [[8397993708429497603]]
-        LOCATE AFTER [[8626927948892135594]]
+        LOCATE BEFORE [[7983855063553809241]]
         INSERT { property alias appLoadView: _appLoadView }
 
         LOCATE AFTER [[7983855063553809241]]


### PR DESCRIPTION
Changing appload.qmd, such that it also works on 3.19 (should still work on 3.18 and previous versions)