### PR TITLE
Add ways scale framebuffer preserving aspect ratio

### DIFF
--- a/resources/qml/window.qml
+++ b/resources/qml/window.qml
@@ -390,6 +390,7 @@ FocusScope {
 
             visible: qtfbKey != -1
             allowScaling: true
+            fillMode: FBController.PreserveAspectFit
             framebufferID: qtfbKey
             focus: qtfbKey != -1
 

--- a/src/qtfb/FBController.cpp
+++ b/src/qtfb/FBController.cpp
@@ -36,10 +36,10 @@ void FBController::paint(QPainter *painter) {
     // Do we have an SHM associated?
     if(this->image && this->_active) {
         // Cool. Paint it.
-        if(_allowScaling) {
-            painter->drawImage(QRect(0, 0, width(), height()), *image, image->rect());
+        if(_allowScaling && _fillMode != Pad) {
+            painter->drawImage(this->convertQTFBRectToScreen(QRect(image->rect())), *image, image->rect());
         } else {
-            painter->drawImage(0, 0, *image);
+            painter->drawImage((width() - image->width()) / 2, (height() - image->height()) / 2, *image);
         }
     } else {
         /*
@@ -73,13 +73,16 @@ void FBController::associateSHM(QImage *image) {
 
 void FBController::markedUpdate(const QRect &rect) {
     isMidPaint = true;
-    if(_allowScaling && image) {
-        update(QRect(
-           (rect.x() / image->width()) * this->width(),
-           (rect.y() / image->height()) * this->height(),
-           (rect.width() / image->width()) * this->width(),
-           (rect.height() / image->height()) * this->height()
-        ));
+
+    if(!rect.isValid()) {
+        // invalid rect means complete update
+        update(rect);
+        return;
+    }
+
+    if(image) {
+        auto updateRect = convertQTFBRectToScreen(rect).adjusted(0, 0, 1, 1);
+        update(updateRect);
     } else {
         update(rect);
     }
@@ -95,6 +98,7 @@ bool FBController::allowScaling() const {
 
 
 QPoint FBController::convertPointToQTFBPixels(const QPointF &input) {
+    // FIXME: do correct translation
     if(_allowScaling && image) {
         return QPoint(
             (input.x() * image->width()) / this->width(),
@@ -102,6 +106,48 @@ QPoint FBController::convertPointToQTFBPixels(const QPointF &input) {
         );
     } else {
         return QPoint(input.x(), input.y());
+    }
+}
+
+QRect FBController::convertQTFBRectToScreen(const QRect &input) {
+    if(_allowScaling && _fillMode != Pad) {
+        if(_fillMode == Stretch) {
+            return QRect(
+                (input.left() * width()) / image->width(),
+                (input.top() * height()) / image->height(),
+                (input.width() * width()) / image->width(),
+                (input.height() * height()) / image->height()
+            );
+        }
+
+        QSize fbSize = this->framebufferSize();
+        float fbAspectRatio = (float)fbSize.width() / fbSize.height();
+        bool  widthOrHeight = fbAspectRatio > (float)width() / height();
+
+        if(   (_fillMode == PreserveAspectFit  &&  widthOrHeight)
+           || (_fillMode == PreserveAspectCrop && !widthOrHeight)) {
+            // scale to fill width, calculate height
+            float calculatedHeight = width() / fbAspectRatio;
+            int fbWidth = image->width();
+            return QRect(
+                (input.left()   * width()) / fbWidth,
+                (input.top()    * width()) / fbWidth + (int)(0.5 * (height() - calculatedHeight)),
+                (input.width()  * width() + fbWidth - 1) / fbWidth, // round width up
+                (input.height() * width() + fbWidth - 1) / fbWidth  // round height up
+            );
+        } else {
+            // scale to fill height, calculate width
+            float calculatedWidth = height() * fbAspectRatio;
+            int fbHeight = image->height();
+            return QRect(
+                (input.left()   * height()) / image->height() + (int)(0.5 * (width() - calculatedWidth)),
+                (input.top()    * height()) / image->height(),
+                (input.width()  * height() + fbHeight - 1) / fbHeight, // round width up
+                (input.height() * height() + fbHeight - 1) / fbHeight  // round height up
+            );
+        }
+    } else {
+        return input.translated((width() - image->width()) / 2, (height() - image->height()) / 2);
     }
 }
 

--- a/src/qtfb/FBController.cpp
+++ b/src/qtfb/FBController.cpp
@@ -111,6 +111,9 @@ QPoint FBController::convertPointToQTFBPixels(const QPointF &input) {
 
 QRect FBController::convertQTFBRectToScreen(const QRect &input) {
     if(_allowScaling && _fillMode != Pad) {
+        int fbWidth = image->width();
+        int fbHeight = image->height();
+
         if(_fillMode == Stretch) {
             return QRect(
                 (input.left() * width()) / image->width(),
@@ -120,15 +123,13 @@ QRect FBController::convertQTFBRectToScreen(const QRect &input) {
             );
         }
 
-        QSize fbSize = this->framebufferSize();
-        float fbAspectRatio = (float)fbSize.width() / fbSize.height();
+        float fbAspectRatio = (float)fbWidth / fbHeight;
         bool  widthOrHeight = fbAspectRatio > (float)width() / height();
 
         if(   (_fillMode == PreserveAspectFit  &&  widthOrHeight)
            || (_fillMode == PreserveAspectCrop && !widthOrHeight)) {
             // scale to fill width, calculate height
             float calculatedHeight = width() / fbAspectRatio;
-            int fbWidth = image->width();
             return QRect(
                 (input.left()   * width()) / fbWidth,
                 (input.top()    * width()) / fbWidth + (int)(0.5 * (height() - calculatedHeight)),
@@ -138,10 +139,9 @@ QRect FBController::convertQTFBRectToScreen(const QRect &input) {
         } else {
             // scale to fill height, calculate width
             float calculatedWidth = height() * fbAspectRatio;
-            int fbHeight = image->height();
             return QRect(
-                (input.left()   * height()) / image->height() + (int)(0.5 * (width() - calculatedWidth)),
-                (input.top()    * height()) / image->height(),
+                (input.left()   * height()) / fbHeight + (int)(0.5 * (width() - calculatedWidth)),
+                (input.top()    * height()) / fbHeight,
                 (input.width()  * height() + fbHeight - 1) / fbHeight, // round width up
                 (input.height() * height() + fbHeight - 1) / fbHeight  // round height up
             );

--- a/src/qtfb/FBController.cpp
+++ b/src/qtfb/FBController.cpp
@@ -22,6 +22,7 @@ bool FBController::active() const {
 void FBController::setActive(bool active){
     _active = active;
     emit activeChanged();
+    emit framebufferSizeChanged();
     markedUpdate();
 }
 
@@ -252,4 +253,11 @@ void FBController::setRefreshMode(int rm) {
         _refreshMode = rm;
         emit refreshModeChanged();
     }
+}
+
+QSize FBController::framebufferSize() const {
+    if(image == nullptr) {
+        return QSize();
+    }
+    return image->size();
 }

--- a/src/qtfb/FBController.cpp
+++ b/src/qtfb/FBController.cpp
@@ -98,12 +98,40 @@ bool FBController::allowScaling() const {
 
 
 QPoint FBController::convertPointToQTFBPixels(const QPointF &input) {
-    // FIXME: do correct translation
     if(_allowScaling && image) {
-        return QPoint(
-            (input.x() * image->width()) / this->width(),
-            (input.y() * image->height()) / this->height() 
-        );
+        int fbWidth = image->width();
+        int fbHeight = image->height();
+
+        if(_fillMode == Stretch) {
+            return QPoint(
+                (input.x() * fbWidth ) / this->width(),
+                (input.y() * fbHeight) / this->height()
+            );
+        }
+        else if(_fillMode == Pad) {
+            return QPoint(
+                input.x() - (width()  - fbWidth ) / 2,
+                input.y() - (height() - fbHeight) / 2
+            );
+        }
+
+        float fbAspectRatio = (float)fbWidth / fbHeight;
+        bool  widthOrHeight = fbAspectRatio > (float)width() / height();
+
+        if(   (_fillMode == PreserveAspectFit  &&  widthOrHeight)
+           || (_fillMode == PreserveAspectCrop && !widthOrHeight)) {
+            // scale to fill width, calculate height
+            float calculatedHeight = width() / fbAspectRatio;
+            return QPoint(
+                (input.x() * fbWidth) / width(),
+                ((input.y() - 0.5 * (height() - calculatedHeight)) * fbWidth) / width());
+        } else {
+            // scale to fill height, calculate width
+            float calculatedWidth = height() * fbAspectRatio;
+            return QPoint(
+                ((input.x() - 0.5 * (width() - calculatedWidth)) * fbHeight) / height(),
+                (input.y() * fbHeight) / height());
+        }
     } else {
         return QPoint(input.x(), input.y());
     }

--- a/src/qtfb/FBController.h
+++ b/src/qtfb/FBController.h
@@ -21,6 +21,7 @@ class FBController : public QQuickPaintedItem
     Q_PROPERTY(int framebufferID READ framebufferID WRITE setFramebufferID)
     Q_PROPERTY(bool allowScaling READ allowScaling WRITE setAllowScaling)
     Q_PROPERTY(int refreshMode READ refreshMode NOTIFY refreshModeChanged)
+    Q_PROPERTY(QSize framebufferSize READ framebufferSize NOTIFY framebufferSizeChanged)
     Q_OBJECT
 public:
     explicit FBController(QQuickItem *parent = nullptr) : QQuickPaintedItem(parent) { setAcceptTouchEvents(true); setAcceptedMouseButtons((Qt::MouseButtons) 0xFFFFFFFF); setFocusPolicy(Qt::StrongFocus); }
@@ -32,6 +33,7 @@ public:
     void setAllowScaling(bool a);
     bool allowScaling() const;
     int refreshMode() const;
+    QSize framebufferSize() const;
     void setRefreshMode(int refreshMode);
 
     bool active() const;
@@ -63,6 +65,7 @@ signals:
     void dragDown();
     void requestFullRefresh();
     void refreshModeChanged();
+    void framebufferSizeChanged();
 
 private:
     int _framebufferID = -1;

--- a/src/qtfb/FBController.h
+++ b/src/qtfb/FBController.h
@@ -22,10 +22,20 @@ class FBController : public QQuickPaintedItem
     Q_PROPERTY(bool allowScaling READ allowScaling WRITE setAllowScaling)
     Q_PROPERTY(int refreshMode READ refreshMode NOTIFY refreshModeChanged)
     Q_PROPERTY(QSize framebufferSize READ framebufferSize NOTIFY framebufferSizeChanged)
+    Q_PROPERTY(FillMode fillMode MEMBER _fillMode)
     Q_OBJECT
 public:
     explicit FBController(QQuickItem *parent = nullptr) : QQuickPaintedItem(parent) { setAcceptTouchEvents(true); setAcceptedMouseButtons((Qt::MouseButtons) 0xFFFFFFFF); setFocusPolicy(Qt::StrongFocus); }
     virtual ~FBController();
+
+    enum FillMode
+    {
+        Stretch,
+        PreserveAspectFit,
+        PreserveAspectCrop,
+        Pad
+    };
+    Q_ENUMS(FillMode)
 
     void setFramebufferID(int fbID);
     int framebufferID() const;
@@ -45,6 +55,7 @@ public:
     void associateSHM(QImage *image);
 
     QPoint convertPointToQTFBPixels(const QPointF &input);
+    QRect convertQTFBRectToScreen(const QRect &input);
 
     virtual void mousePressEvent(QMouseEvent *me) override;
     virtual void mouseMoveEvent(QMouseEvent *me) override;
@@ -72,6 +83,7 @@ private:
     int _refreshMode = DEFAULT_WAVEFORM_MODE;
     bool _active = false;
     bool _allowScaling = false;
+    FillMode _fillMode = Stretch;
 
     bool checkingGestureDragDown = false;
     bool refreshedScreenAlready = false;


### PR DESCRIPTION
This PR adds the fillMode property to the FBController component. It works similar to the property of the same name in the [standard QTQuick Image component](https://doc.qt.io/qt-6/qml-qtquick-image.html#fillMode-prop), but does not support tiling.
It also adds the framebufferSize property, allowing QML to know the width and height of the allocated frambuffer.

One open question is, whether the allowScaling property and its behaviour needs to be preserved for backwards compatibility reasons, or if `fillMode: FBController.Pad` is a good enough replacement. Right now it is a bit of a mix.

PS: [geloescht:micropaint](https://github.com/geloescht/rm-appload/tree/micropaint) has an additional example that I used to help with the development of this feature.