### PR TITLE
set the qtfb shm umask to 0666 so processes running as a user can connect

### DIFF
--- a/src/qtfb/fbmanagement.cpp
+++ b/src/qtfb/fbmanagement.cpp
@@ -111,7 +111,7 @@ static bool createSHM(qtfb::management::ClientBackend *connection, int shmType, 
     connection->shmKey = rand() & ~0x80000000;
     FORMAT_SHM(shmText, connection->shmKey);
     shm_unlink(shmText);
-    connection->shmFD = shm_open(shmText, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+    connection->shmFD = shm_open(shmText, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
     if(connection->shmFD == -1) {
         CERR << "Failed to shm_open()!" << std::endl;
         return false;


### PR DESCRIPTION
this is another PR driven by my wlroots project. A lot of apps like chrome really don't like running as root, so i want to be able to run as a regular user inside the chroot. The /tmp/qtfb.sock I can just chmod in my launch script, but by the time the shm file is created the permissions to do that have already been dropped.