### PR TITLE
Add support for fast eink + marker access

### DIFF
--- a/src/inkcanvas.cpp
+++ b/src/inkcanvas.cpp
@@ -11,7 +11,7 @@ InkCanvas::InkCanvas(QQuickItem *parent)
     setRenderTarget(QQuickPaintedItem::Image);
     setOpaquePainting(false);
     setFillColor(Qt::transparent);
-    setAntialiasing(false);
+    setAntialiasing(m_antialias);
     setMipmap(false);
 }
 
@@ -33,6 +33,17 @@ void InkCanvas::setColor(const QColor &c)
     emit colorChanged();
 }
 
+void InkCanvas::setAntialias(bool on)
+{
+    if (m_antialias == on) {
+        return;
+    }
+    m_antialias = on;
+    setAntialiasing(on);
+    emit antialiasChanged();
+    update();
+}
+
 void InkCanvas::geometryChange(const QRectF &newGeometry, const QRectF &oldGeometry)
 {
     QQuickPaintedItem::geometryChange(newGeometry, oldGeometry);
@@ -41,7 +52,9 @@ void InkCanvas::geometryChange(const QRectF &newGeometry, const QRectF &oldGeome
 
 QRectF InkCanvas::segmentBounds(const Segment &s) const
 {
-    const qreal m = m_penWidth / 2.0 + 1.0;
+    // Half the stroke width, plus a margin that covers the round cap and the
+    // extra fringe pixels antialiasing adds.
+    const qreal m = s.width / 2.0 + (m_antialias ? 2.0 : 1.0);
     const qreal minX = std::min(s.a.x(), s.b.x()) - m;
     const qreal minY = std::min(s.a.y(), s.b.y()) - m;
     const qreal maxX = std::max(s.a.x(), s.b.x()) + m;
@@ -55,7 +68,7 @@ void InkCanvas::moveTo(qreal x, qreal y)
     m_hasLast = true;
 }
 
-void InkCanvas::lineTo(qreal x, qreal y)
+void InkCanvas::lineTo(qreal x, qreal y, qreal width)
 {
     const QPointF p(x, y);
     if (!m_hasLast) {
@@ -64,7 +77,7 @@ void InkCanvas::lineTo(qreal x, qreal y)
         return;
     }
 
-    const Segment seg{m_last, p};
+    const Segment seg{m_last, p, width < 0.0 ? m_penWidth : width};
     m_segments.append(seg);
     m_last = p;
 
@@ -136,17 +149,17 @@ void InkCanvas::paint(QPainter *painter)
     QRectF clip = painter->clipBoundingRect();
     const bool haveClip = clip.isValid() && !clip.isEmpty();
 
-    painter->setRenderHint(QPainter::Antialiasing, false);
+    painter->setRenderHint(QPainter::Antialiasing, m_antialias);
     QPen pen(m_color);
-    pen.setWidthF(m_penWidth);
     pen.setCapStyle(Qt::RoundCap);
     pen.setJoinStyle(Qt::RoundJoin);
-    painter->setPen(pen);
 
     for (const Segment &seg : m_segments) {
         if (haveClip && !segmentBounds(seg).intersects(clip)) {
             continue;
         }
+        pen.setWidthF(seg.width);
+        painter->setPen(pen);
         painter->drawLine(seg.a, seg.b);
     }
 }

--- a/src/inkcanvas.cpp
+++ b/src/inkcanvas.cpp
@@ -1,0 +1,152 @@
+#include "inkcanvas.h"
+
+#include <QPainter>
+
+#include <algorithm>
+#include <cmath>
+
+InkCanvas::InkCanvas(QQuickItem *parent)
+    : QQuickPaintedItem(parent)
+{
+    setRenderTarget(QQuickPaintedItem::Image);
+    setOpaquePainting(false);
+    setFillColor(Qt::transparent);
+    setAntialiasing(false);
+    setMipmap(false);
+}
+
+void InkCanvas::setPenWidth(qreal w)
+{
+    if (qFuzzyCompare(m_penWidth, w)) {
+        return;
+    }
+    m_penWidth = w;
+    emit penWidthChanged();
+}
+
+void InkCanvas::setColor(const QColor &c)
+{
+    if (m_color == c) {
+        return;
+    }
+    m_color = c;
+    emit colorChanged();
+}
+
+void InkCanvas::geometryChange(const QRectF &newGeometry, const QRectF &oldGeometry)
+{
+    QQuickPaintedItem::geometryChange(newGeometry, oldGeometry);
+    setContentsSize(newGeometry.size().toSize());
+}
+
+QRectF InkCanvas::segmentBounds(const Segment &s) const
+{
+    const qreal m = m_penWidth / 2.0 + 1.0;
+    const qreal minX = std::min(s.a.x(), s.b.x()) - m;
+    const qreal minY = std::min(s.a.y(), s.b.y()) - m;
+    const qreal maxX = std::max(s.a.x(), s.b.x()) + m;
+    const qreal maxY = std::max(s.a.y(), s.b.y()) + m;
+    return QRectF(minX, minY, maxX - minX, maxY - minY);
+}
+
+void InkCanvas::moveTo(qreal x, qreal y)
+{
+    m_last = QPointF(x, y);
+    m_hasLast = true;
+}
+
+void InkCanvas::lineTo(qreal x, qreal y)
+{
+    const QPointF p(x, y);
+    if (!m_hasLast) {
+        m_last = p;
+        m_hasLast = true;
+        return;
+    }
+
+    const Segment seg{m_last, p};
+    m_segments.append(seg);
+    m_last = p;
+
+    // Only invalidate the segment's bounding box so the epaper backend refreshes
+    // the smallest possible region of the panel.
+    update(segmentBounds(seg).toAlignedRect());
+}
+
+void InkCanvas::clear()
+{
+    m_segments.clear();
+    m_hasLast = false;
+    update();
+}
+
+void InkCanvas::eraseAt(qreal x, qreal y, qreal radius)
+{
+    // Remove every segment that passes within `radius` pixels of (x, y).
+    const QPointF p(x, y);
+    const qreal r2 = radius * radius;
+
+    QRectF dirty;
+    bool any = false;
+
+    auto pointToSegmentDist2 = [](QPointF p, QPointF a, QPointF b) -> qreal {
+        const QPointF ab = b - a;
+        const qreal len2 = ab.x() * ab.x() + ab.y() * ab.y();
+        if (len2 < 1e-10) {
+            QPointF d = p - a;
+            return d.x() * d.x() + d.y() * d.y();
+        }
+        const qreal t = qBound(0.0,
+            ((p.x() - a.x()) * ab.x() + (p.y() - a.y()) * ab.y()) / len2,
+            1.0);
+        const QPointF proj(a.x() + t * ab.x(), a.y() + t * ab.y());
+        const QPointF d = p - proj;
+        return d.x() * d.x() + d.y() * d.y();
+    };
+
+    QList<Segment> kept;
+    kept.reserve(m_segments.size());
+
+    for (const Segment &seg : m_segments) {
+        if (pointToSegmentDist2(p, seg.a, seg.b) < r2) {
+            const QRectF sb = segmentBounds(seg);
+            dirty = any ? dirty.united(sb) : sb;
+            any = true;
+        } else {
+            kept.append(seg);
+        }
+    }
+
+    if (any) {
+        m_segments = std::move(kept);
+        const QRectF eraserRect(x - radius, y - radius, radius * 2, radius * 2);
+        dirty = dirty.united(eraserRect);
+        update(dirty.adjusted(-1, -1, 1, 1).toAlignedRect());
+    }
+
+    m_hasLast = false;
+}
+
+void InkCanvas::paint(QPainter *painter)
+{
+    if (m_segments.isEmpty()) {
+        return;
+    }
+
+    QRectF clip = painter->clipBoundingRect();
+    const bool haveClip = clip.isValid() && !clip.isEmpty();
+
+    painter->setRenderHint(QPainter::Antialiasing, false);
+    QPen pen(m_color);
+    pen.setWidthF(m_penWidth);
+    pen.setCapStyle(Qt::RoundCap);
+    pen.setJoinStyle(Qt::RoundJoin);
+    painter->setPen(pen);
+
+    for (const Segment &seg : m_segments) {
+        if (haveClip && !segmentBounds(seg).intersects(clip)) {
+            continue;
+        }
+        painter->drawLine(seg.a, seg.b);
+    }
+}

--- a/src/inkcanvas.h
+++ b/src/inkcanvas.h
@@ -23,6 +23,7 @@ class InkCanvas : public QQuickPaintedItem
     Q_OBJECT
     Q_PROPERTY(qreal penWidth READ penWidth WRITE setPenWidth NOTIFY penWidthChanged)
     Q_PROPERTY(QColor color READ color WRITE setColor NOTIFY colorChanged)
+    Q_PROPERTY(bool antialias READ antialias WRITE setAntialias NOTIFY antialiasChanged)
 
 public:
     explicit InkCanvas(QQuickItem *parent = nullptr);
@@ -33,8 +34,13 @@ public:
     QColor color() const { return m_color; }
     void setColor(const QColor &c);
 
+    bool antialias() const { return m_antialias; }
+    void setAntialias(bool on);
+
     Q_INVOKABLE void moveTo(qreal x, qreal y);
-    Q_INVOKABLE void lineTo(qreal x, qreal y);
+    // width < 0 falls back to penWidth; pass a per-stroke width (e.g. derived
+    // from pen pressure) to vary line thickness within a stroke.
+    Q_INVOKABLE void lineTo(qreal x, qreal y, qreal width = -1.0);
     Q_INVOKABLE void eraseAt(qreal x, qreal y, qreal radius);
     Q_INVOKABLE void clear();
 
@@ -43,6 +49,7 @@ public:
 signals:
     void penWidthChanged();
     void colorChanged();
+    void antialiasChanged();
 
 protected:
     void geometryChange(const QRectF &newGeometry, const QRectF &oldGeometry) override;
@@ -51,12 +58,14 @@ private:
     struct Segment {
         QPointF a;
         QPointF b;
+        qreal width;
     };
 
     QRectF segmentBounds(const Segment &s) const;
 
     qreal m_penWidth = 3.0;
     QColor m_color = Qt::black;
+    bool m_antialias = true;
 
     QList<Segment> m_segments;
     QPointF m_last;

--- a/src/inkcanvas.h
+++ b/src/inkcanvas.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <QColor>
+#include <QList>
+#include <QPointF>
+#include <QRectF>
+#include <QQuickPaintedItem>
+
+// Ink surface built on QQuickPaintedItem — the draw path the reMarkable epaper
+// scene-graph backend is designed for (EPContext::createPainterNode) and the one
+// the native handwriting UI uses. Unlike a QML Canvas (which renders to an
+// offscreen FBO/texture and never hits the epaper painter node), a
+// QQuickPaintedItem maps to that node, so each per-segment update(smallRect)
+// refreshes just that tiny region of the e-ink panel, matching native
+// handwriting speed.
+//
+// Pair it in QML with a ScreenModeItem in Pen mode (import xofm.libs.epaper) to
+// select the fast handwriting waveform for the same region.
+//
+// Registered by the AppLoad xovi extension as `import net.asivery.Ink 1.0`.
+class InkCanvas : public QQuickPaintedItem
+{
+    Q_OBJECT
+    Q_PROPERTY(qreal penWidth READ penWidth WRITE setPenWidth NOTIFY penWidthChanged)
+    Q_PROPERTY(QColor color READ color WRITE setColor NOTIFY colorChanged)
+
+public:
+    explicit InkCanvas(QQuickItem *parent = nullptr);
+
+    qreal penWidth() const { return m_penWidth; }
+    void setPenWidth(qreal w);
+
+    QColor color() const { return m_color; }
+    void setColor(const QColor &c);
+
+    Q_INVOKABLE void moveTo(qreal x, qreal y);
+    Q_INVOKABLE void lineTo(qreal x, qreal y);
+    Q_INVOKABLE void eraseAt(qreal x, qreal y, qreal radius);
+    Q_INVOKABLE void clear();
+
+    void paint(QPainter *painter) override;
+
+signals:
+    void penWidthChanged();
+    void colorChanged();
+
+protected:
+    void geometryChange(const QRectF &newGeometry, const QRectF &oldGeometry) override;
+
+private:
+    struct Segment {
+        QPointF a;
+        QPointF b;
+    };
+
+    QRectF segmentBounds(const Segment &s) const;
+
+    qreal m_penWidth = 3.0;
+    QColor m_color = Qt::black;
+
+    QList<Segment> m_segments;
+    QPointF m_last;
+    bool m_hasLast = false;
+};

--- a/src/markerinput.cpp
+++ b/src/markerinput.cpp
@@ -1,0 +1,210 @@
+#include "markerinput.h"
+
+#include <QMetaObject>
+
+#include <linux/input.h>
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+constexpr int kBitsPerLong = 8 * sizeof(unsigned long);
+
+inline bool testBit(const unsigned long *arr, int bit)
+{
+    return (arr[bit / kBitsPerLong] >> (bit % kBitsPerLong)) & 1UL;
+}
+
+// A device is the marker if it reports absolute X/Y and a pen/stylus tool.
+// This deliberately excludes the multitouch panel (ABS_MT_* + BTN_TOUCH but no
+// BTN_TOOL_PEN), so palm contact is never read.
+bool isPenDevice(int fd)
+{
+    unsigned long absBits[(ABS_MAX / kBitsPerLong) + 1] = {0};
+    unsigned long keyBits[(KEY_MAX / kBitsPerLong) + 1] = {0};
+
+    if (ioctl(fd, EVIOCGBIT(EV_ABS, sizeof(absBits)), absBits) < 0)
+        return false;
+    if (ioctl(fd, EVIOCGBIT(EV_KEY, sizeof(keyBits)), keyBits) < 0)
+        return false;
+
+    const bool hasAbs = testBit(absBits, ABS_X) && testBit(absBits, ABS_Y);
+    const bool isPen = testBit(keyBits, BTN_TOOL_PEN) || testBit(keyBits, BTN_STYLUS);
+    return hasAbs && isPen;
+}
+
+// Query [min, max] for an absolute axis; max is forced strictly above min so
+// later normalisation never divides by zero.
+void axisRange(int fd, int axis, int &min, int &max)
+{
+    struct input_absinfo info;
+    std::memset(&info, 0, sizeof(info));
+    if (ioctl(fd, EVIOCGABS(axis), &info) < 0) {
+        min = 0;
+        max = 1;
+        return;
+    }
+    min = info.minimum;
+    max = info.maximum > info.minimum ? info.maximum : info.minimum + 1;
+}
+
+} // namespace
+
+MarkerInput::MarkerInput(QObject *parent)
+    : QObject(parent)
+{
+}
+
+MarkerInput::~MarkerInput()
+{
+    m_running = false;
+    // Closing the fd unblocks the reader's blocking read() so it can exit.
+    if (m_fd >= 0) {
+        ::close(m_fd);
+        m_fd = -1;
+    }
+    if (m_thread.joinable())
+        m_thread.join();
+}
+
+void MarkerInput::setScreenWidth(qreal w)
+{
+    if (qFuzzyCompare(m_screenWidth, w))
+        return;
+    m_screenWidth = w;
+    emit screenSizeChanged();
+}
+
+void MarkerInput::setScreenHeight(qreal h)
+{
+    if (qFuzzyCompare(m_screenHeight, h))
+        return;
+    m_screenHeight = h;
+    emit screenSizeChanged();
+}
+
+void MarkerInput::open()
+{
+    if (m_active)
+        return;
+
+    int fd = -1;
+    DIR *dir = ::opendir("/dev/input");
+    if (dir) {
+        struct dirent *ent;
+        while ((ent = ::readdir(dir)) != nullptr) {
+            if (std::strncmp(ent->d_name, "event", 5) != 0)
+                continue;
+            char path[288];
+            std::snprintf(path, sizeof(path), "/dev/input/%s", ent->d_name);
+            int candidate = ::open(path, O_RDONLY);
+            if (candidate < 0)
+                continue;
+            if (isPenDevice(candidate)) {
+                fd = candidate;
+                break;
+            }
+            ::close(candidate);
+        }
+        ::closedir(dir);
+    }
+
+    if (fd < 0) {
+        std::fprintf(stderr, "[MarkerInput] no marker device found under /dev/input\n");
+        return;
+    }
+
+    int minX, maxX, minY, maxY, minP, maxP;
+    axisRange(fd, ABS_X, minX, maxX);
+    axisRange(fd, ABS_Y, minY, maxY);
+    axisRange(fd, ABS_PRESSURE, minP, maxP);
+
+    m_fd = fd;
+    m_running = true;
+    m_active = true;
+    emit activeChanged();
+
+    m_thread = std::thread([this, fd, minX, maxX, minY, maxY, minP, maxP]() {
+        readerLoop(fd, minX, maxX, minY, maxY, minP, maxP);
+    });
+}
+
+void MarkerInput::readerLoop(int fd, int minX, int maxX, int minY, int maxY, int minP, int maxP)
+{
+    int rawX = 0, rawY = 0, rawP = 0;
+    bool penDown = false;
+    bool eraserDown = false;
+    // BTN_TOOL_RUBBER = eraser end in proximity (hover); BTN_TOUCH = contact.
+    // penDown = touch AND NOT rubber; eraserDown = touch AND rubber.
+    bool toolRubber = false;
+
+    struct input_event ev;
+    while (m_running.load()) {
+        const ssize_t n = ::read(fd, &ev, sizeof(ev));
+        if (n != static_cast<ssize_t>(sizeof(ev))) {
+            if (n < 0 && errno == EINTR)
+                continue;
+            break; // fd closed or error -> stop
+        }
+
+        switch (ev.type) {
+        case EV_ABS:
+            if (ev.code == ABS_X)
+                rawX = ev.value;
+            else if (ev.code == ABS_Y)
+                rawY = ev.value;
+            else if (ev.code == ABS_PRESSURE)
+                rawP = ev.value;
+            break;
+
+        case EV_KEY:
+            if (ev.code == BTN_TOUCH) {
+                const bool touching = ev.value != 0;
+                penDown = touching && !toolRubber;
+                eraserDown = touching && toolRubber;
+            } else if (ev.code == BTN_TOOL_RUBBER) {
+                toolRubber = ev.value != 0;
+                if (!toolRubber)
+                    eraserDown = false;
+            }
+            break;
+
+        case EV_SYN:
+            if (ev.code == SYN_REPORT) {
+                const qreal nx = qBound(0.0,
+                    static_cast<qreal>(rawX - minX) / static_cast<qreal>(maxX - minX), 1.0);
+                const qreal ny = qBound(0.0,
+                    static_cast<qreal>(rawY - minY) / static_cast<qreal>(maxY - minY), 1.0);
+                const qreal np = qBound(0.0,
+                    static_cast<qreal>(rawP - minP) / static_cast<qreal>(maxP - minP), 1.0);
+
+                // Marshal onto the GUI thread; the lambda runs in this object's
+                // thread affinity (where QML lives) via the event loop.
+                QMetaObject::invokeMethod(this, [this, nx, ny, np, penDown, eraserDown]() {
+                    applyFrame(nx, ny, np, penDown, eraserDown);
+                }, Qt::QueuedConnection);
+            }
+            break;
+
+        default:
+            break;
+        }
+    }
+}
+
+void MarkerInput::applyFrame(qreal normX, qreal normY, qreal pressure, bool penDown, bool eraserDown)
+{
+    m_penX = normX * m_screenWidth;
+    m_penY = normY * m_screenHeight;
+    m_pressure = pressure;
+    m_penDown = penDown;
+    m_eraserDown = eraserDown;
+    emit penChanged();
+}

--- a/src/markerinput.h
+++ b/src/markerinput.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <QObject>
+#include <QtGlobal>
+
+#include <atomic>
+#include <thread>
+
+// MarkerInput — low-level pen/marker reader for AppLoad apps.
+//
+// The reMarkable epaper platform plugin does NOT forward the Wacom digitizer
+// into Qt's tablet/pointer pipeline; xochitl reads it and only re-injects
+// coalesced MOUSE events. That loses pressure, the eraser tool, and the full
+// sample rate, and it can't be told apart from a palm on the (separate)
+// multitouch panel.
+//
+// Because an AppLoad extension runs INSIDE the xochitl process, we can read the
+// pen digitizer's evdev stream directly here — exactly like the standalone
+// reference app's PenInput — and expose it to QML. Reading ONLY the pen device
+// gives palm rejection for free (the palm lands on a different input device),
+// and gives penDown / eraserDown (BTN_TOOL_RUBBER) / pressure / raw coords.
+//
+// Registered as `import net.asivery.Marker 1.0` -> MarkerInput.
+//
+// QML usage (mirrors the reference):
+//   MarkerInput { id: marker }
+//   Component.onCompleted: { marker.screenWidth = root.width;
+//                            marker.screenHeight = root.height; marker.open() }
+//   Connections { target: marker; function onPenChanged() { ... } }
+class MarkerInput : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(qreal penX READ penX NOTIFY penChanged)
+    Q_PROPERTY(qreal penY READ penY NOTIFY penChanged)
+    Q_PROPERTY(qreal pressure READ pressure NOTIFY penChanged)
+    Q_PROPERTY(bool penDown READ penDown NOTIFY penChanged)
+    Q_PROPERTY(bool eraserDown READ eraserDown NOTIFY penChanged)
+    Q_PROPERTY(bool active READ active NOTIFY activeChanged)
+    Q_PROPERTY(qreal screenWidth READ screenWidth WRITE setScreenWidth NOTIFY screenSizeChanged)
+    Q_PROPERTY(qreal screenHeight READ screenHeight WRITE setScreenHeight NOTIFY screenSizeChanged)
+
+public:
+    explicit MarkerInput(QObject *parent = nullptr);
+    ~MarkerInput() override;
+
+    qreal penX() const { return m_penX; }
+    qreal penY() const { return m_penY; }
+    qreal pressure() const { return m_pressure; }
+    bool penDown() const { return m_penDown; }
+    bool eraserDown() const { return m_eraserDown; }
+    bool active() const { return m_active; }
+
+    qreal screenWidth() const { return m_screenWidth; }
+    qreal screenHeight() const { return m_screenHeight; }
+    void setScreenWidth(qreal w);
+    void setScreenHeight(qreal h);
+
+    // Detect the marker device and start the background reader thread.
+    // Safe to call more than once; a no-op once active.
+    Q_INVOKABLE void open();
+
+signals:
+    void penChanged();
+    void activeChanged();
+    void screenSizeChanged();
+
+private:
+    // Blocks on the device fd; marshals one frame per SYN_REPORT to the GUI
+    // thread. Runs on m_thread.
+    void readerLoop(int fd, int minX, int maxX, int minY, int maxY, int minP, int maxP);
+
+    // Applied on the GUI thread (queued from the reader thread).
+    void applyFrame(qreal normX, qreal normY, qreal pressure, bool penDown, bool eraserDown);
+
+    qreal m_penX = 0.0;
+    qreal m_penY = 0.0;
+    qreal m_pressure = 0.0;
+    bool m_penDown = false;
+    bool m_eraserDown = false;
+    bool m_active = false;
+    qreal m_screenWidth = 0.0;
+    qreal m_screenHeight = 0.0;
+
+    std::thread m_thread;
+    std::atomic<bool> m_running{false};
+    int m_fd = -1;
+};

--- a/xovi/template/appload.pro
+++ b/xovi/template/appload.pro
@@ -1,10 +1,16 @@
-QT     += core gui qml quickcontrols2
+QT     += core gui qml quick quickcontrols2
 
 TARGET = appload
 TEMPLATE = lib
 CONFIG += shared plugin no_plugin_name_prefix
 
-SOURCES += src/main.cpp xovi.cpp src/management.cpp src/AppLoad.cpp src/AppLoadCoordinator.cpp src/library.cpp src/libraryexternals.cpp src/qtfb/fbmanagement.cpp src/qtfb/FBController.cpp src/keyboard/layout.cpp
+# The RMPP SDK links Qt6Quick's GL deps (libQt6OpenGL, libGLX, libOpenGL) which
+# do NOT exist on the epaper device (xochitl uses the software/epaper backend).
+# InkCanvas only uses QPainter + QQuickPaintedItem (no OpenGL), so --as-needed
+# drops those unused libs from NEEDED and lets the extension dlopen on-device.
+QMAKE_LFLAGS += -Wl,--as-needed
+
+SOURCES += src/main.cpp xovi.cpp src/management.cpp src/AppLoad.cpp src/AppLoadCoordinator.cpp src/library.cpp src/libraryexternals.cpp src/qtfb/fbmanagement.cpp src/qtfb/FBController.cpp src/keyboard/layout.cpp src/inkcanvas.cpp
 HEADERS += src/AppLoad.h src/AppLoadCoordinator.h src/library.h src/AppLibrary.h \
-            src/qtfb/FBController.h src/qtfb/fbmanagement.h src/keyboard/layout.h src/Launcher.h
+            src/qtfb/FBController.h src/qtfb/fbmanagement.h src/keyboard/layout.h src/Launcher.h src/inkcanvas.h
 

--- a/xovi/template/appload.pro
+++ b/xovi/template/appload.pro
@@ -10,7 +10,7 @@ CONFIG += shared plugin no_plugin_name_prefix
 # drops those unused libs from NEEDED and lets the extension dlopen on-device.
 QMAKE_LFLAGS += -Wl,--as-needed
 
-SOURCES += src/main.cpp xovi.cpp src/management.cpp src/AppLoad.cpp src/AppLoadCoordinator.cpp src/library.cpp src/libraryexternals.cpp src/qtfb/fbmanagement.cpp src/qtfb/FBController.cpp src/keyboard/layout.cpp src/inkcanvas.cpp
+SOURCES += src/main.cpp xovi.cpp src/management.cpp src/AppLoad.cpp src/AppLoadCoordinator.cpp src/library.cpp src/libraryexternals.cpp src/qtfb/fbmanagement.cpp src/qtfb/FBController.cpp src/keyboard/layout.cpp src/inkcanvas.cpp src/markerinput.cpp
 HEADERS += src/AppLoad.h src/AppLoadCoordinator.h src/library.h src/AppLibrary.h \
-            src/qtfb/FBController.h src/qtfb/fbmanagement.h src/keyboard/layout.h src/Launcher.h src/inkcanvas.h
+            src/qtfb/FBController.h src/qtfb/fbmanagement.h src/keyboard/layout.h src/Launcher.h src/inkcanvas.h src/markerinput.h
 

--- a/xovi/template/src/main.cpp
+++ b/xovi/template/src/main.cpp
@@ -9,6 +9,7 @@
 #include "AppLibrary.h"
 #include "AppLoad.h"
 #include "inkcanvas.h"
+#include "markerinput.h"
 #include "management.h"
 #include "library.h"
 #include "xovi.h"
@@ -28,6 +29,7 @@ extern "C" {
         qmlRegisterType<AppLoadApplication>("net.asivery.AppLoad", 1, 0, "AppLoadApplication");
         qmlRegisterType<FBController>("net.asivery.Framebuffer", 1, 0, "FBController");
         qmlRegisterType<InkCanvas>("net.asivery.Ink", 1, 0, "InkCanvas");
+        qmlRegisterType<MarkerInput>("net.asivery.Marker", 1, 0, "MarkerInput");
         qmlRegisterSingletonType<AppLoadLauncher>("net.asivery.AppLoad", 1, 0, "AppLoadLauncher", &AppLoadLauncher::qmlSingleton);
         qt_resource_rebuilder$qmldiff_add_external_diff(r$apploadDiff, "AppLoad hooks in main UI");
 

--- a/xovi/template/src/main.cpp
+++ b/xovi/template/src/main.cpp
@@ -8,6 +8,7 @@
 #include "Launcher.h"
 #include "AppLibrary.h"
 #include "AppLoad.h"
+#include "inkcanvas.h"
 #include "management.h"
 #include "library.h"
 #include "xovi.h"
@@ -26,6 +27,7 @@ extern "C" {
         qmlRegisterType<AppLoadLibrary>("net.asivery.AppLoad", 1, 0, "AppLoadLibrary");
         qmlRegisterType<AppLoadApplication>("net.asivery.AppLoad", 1, 0, "AppLoadApplication");
         qmlRegisterType<FBController>("net.asivery.Framebuffer", 1, 0, "FBController");
+        qmlRegisterType<InkCanvas>("net.asivery.Ink", 1, 0, "InkCanvas");
         qmlRegisterSingletonType<AppLoadLauncher>("net.asivery.AppLoad", 1, 0, "AppLoadLauncher", &AppLoadLauncher::qmlSingleton);
         qt_resource_rebuilder$qmldiff_add_external_diff(r$apploadDiff, "AppLoad hooks in main UI");
 


### PR DESCRIPTION
Adds a InkCanvas component, built off of QQuickPaintedItem, to support the fast small refresh writing, like xochitl uses for its notes. Links against libQt6Quick for QQuickPaintedItem. 

This code is entirely AI generated, but has been tested and I've taken a quick look through it. Looks to be serviceable. 

Note: has only been tested on the reMarkable Paper Pro, as that's the only one I got lol. 