### PR TITLE
Do content and window scaling more consistently for QTFB applications

### DIFF
--- a/resources/qml/window.qml
+++ b/resources/qml/window.qml
@@ -162,10 +162,8 @@ FocusScope {
             startY = mouse.y
 
             if(!supportsScaling) {
-                let scale = Math.min(height / root.globalHeight, width / root.globalWidth);
-
-                width = root.globalWidth * scale
-                height = root.globalHeight * scale + topbar.height
+                let scale = width / root.scaledContentWidth
+                height = root.scaledContentHeight * scale
             }
 
             root.width = width;
@@ -353,40 +351,7 @@ FocusScope {
 
         FBController {
             id: windowCanvas
-            property var deviceAspectRatio: root.globalWidth / root.globalHeight
-            property var contentAspectRatio: root.scaledContentWidth / root.scaledContentHeight
-            states: [
-                State {
-                    name: "a"
-                    when: windowCanvas.deviceAspectRatio == windowCanvas.contentAspectRatio
-                    PropertyChanges {
-                        target: windowCanvas
-                        width: parent.width
-                        height: parent.height
-                    }
-                },
-                State {
-                    name: "b"
-                    when: windowCanvas.deviceAspectRatio > windowCanvas.contentAspectRatio
-
-                    PropertyChanges {
-                        target: windowCanvas
-                        height: parent.height
-                        width: windowCanvas.contentAspectRatio * parent.height
-                    }
-                },
-                State {
-                    name: "c"
-                    when: windowCanvas.contentAspectRatio > windowCanvas.deviceAspectRatio
-
-                    PropertyChanges {
-                        target: windowCanvas
-                        width: parent.width
-                        height: parent.width / windowCanvas.contentAspectRatio
-                    }
-                }
-            ]
-            anchors.centerIn: parent
+            anchors.fill: parent
 
             visible: qtfbKey != -1
             allowScaling: true

--- a/src/AppLibrary.h
+++ b/src/AppLibrary.h
@@ -157,7 +157,7 @@ public:
             _applications.append(new AppLoadApplication(entry.first,
                                                         entry.second->getAppName(),
                                                         entry.second->getIconPath(),
-                                                        false,
+                                                        entry.second->aspectRatio() == 0, // do not constrain window size if aspectRatio is set to "auto"
                                                         true,
                                                         entry.second->isQTFB() ? EXTERNAL_QTFB : EXTERNAL_NOGUI,
                                                         entry.second->aspectRatio(),

--- a/src/library.h
+++ b/src/library.h
@@ -117,4 +117,5 @@ namespace appload::library {
     appload::library::LoadedApplication *get(const QString &id);
     const std::map<QString, appload::library::LoadedApplication*> &getRef();
     const std::map<QString, appload::library::ExternalApplication*> &getExternals();
+    std::tuple<float, int> parseAspectRatioAndWidth(const QJsonObject&, const QString&);
 };

--- a/src/qtfb/FBController.cpp
+++ b/src/qtfb/FBController.cpp
@@ -166,37 +166,42 @@ QRect FBController::convertQTFBRectToScreen(const QRect &input) {
     }
 }
 
-
-void FBController::mousePressEvent(QMouseEvent *me) {
+void FBController::mouseEvent(QMouseEvent *me, int inputType) {
+    bool reject = false;
     if(framebufferID != -1 && !me->points().isEmpty()) {
         const QEventPoint &point = me->points()[0];
         QPoint conv = convertPointToQTFBPixels(point.position());
-        qtfb::UserInputContents packet {
-            .inputType = INPUT_PEN_PRESS,
-            .devId = 0, // TODO - differentiate between pen / eraser.
-            .x = conv.x(),
-            .y = conv.y(),
-            .d = (int) (point.pressure() * 100.0),
-        };
-        qtfb::management::forwardUserInput(framebufferID, &packet);
+
+        // only forward and accept events that fall into the framebuffer display region
+        if(image && (conv.x() < 0 || conv.x() > image->width() || conv.y() < 0 || conv.y() > image->height())) {
+            reject = true;
+        } else {
+            qtfb::UserInputContents packet {
+                .inputType = inputType,
+                .devId = 0, // TODO - differentiate between pen / eraser.
+                .x = conv.x(),
+                .y = conv.y(),
+                .d = (int) (point.pressure() * 100.0),
+            };
+            qtfb::management::forwardUserInput(framebufferID, &packet);
+        }
     }
-    me->accept();
+
+    if(!reject) {
+        me->accept();
+    }
+}
+
+void FBController::mousePressEvent(QMouseEvent *me) {
+    mouseEvent(me, INPUT_PEN_PRESS);
 }
 
 void FBController::mouseMoveEvent(QMouseEvent *me) {
-    if(framebufferID != -1 && !me->points().isEmpty()) {
-        const QEventPoint &point = me->points()[0];
-        QPoint conv = convertPointToQTFBPixels(point.position());
-        qtfb::UserInputContents packet {
-            .inputType = INPUT_PEN_UPDATE,
-            .devId = 0,
-            .x = conv.x(),
-            .y = conv.y(),
-            .d = (int) (point.pressure() * 100.0),
-        };
-        qtfb::management::forwardUserInput(framebufferID, &packet);
-    }
-    me->accept();
+    mouseEvent(me, INPUT_PEN_UPDATE);
+}
+
+void FBController::mouseReleaseEvent(QMouseEvent *me) {
+    mouseEvent(me, INPUT_PEN_RELEASE);
 }
 
 static inline void sendKeyEvent(int key, int pkt, qtfb::FBKey framebufferID) {
@@ -228,21 +233,6 @@ void FBController::specialKeyUp(int key) {
     sendKeyEvent(key, INPUT_BTN_RELEASE, framebufferID);
 }
 
-void FBController::mouseReleaseEvent(QMouseEvent *me) {
-    if(framebufferID != -1) {
-        QPoint conv = convertPointToQTFBPixels(me->position());
-        qtfb::UserInputContents packet {
-            .inputType = INPUT_PEN_RELEASE,
-            .devId = 0,
-            .x = conv.x(),
-            .y = conv.y(),
-            .d = 0,
-        };
-        qtfb::management::forwardUserInput(framebufferID, &packet);
-    }
-    me->accept();
-}
-
 void FBController::touchEvent(QTouchEvent *me) {
     if(framebufferID != -1) {
         int lenPoints = me->points().length();
@@ -253,6 +243,7 @@ void FBController::touchEvent(QTouchEvent *me) {
         }
         for(const QEventPoint& point : me->points()) {
             QPoint conv = convertPointToQTFBPixels(point.position());
+            QPoint pressConv = convertPointToQTFBPixels(point.pressPosition());
             qtfb::UserInputContents packet {
                 .inputType = INPUT_TOUCH_PRESS,
                 .devId = point.id(),
@@ -263,25 +254,30 @@ void FBController::touchEvent(QTouchEvent *me) {
             switch(point.state()) {
                 case QEventPoint::State::Pressed:
                     packet.inputType = INPUT_TOUCH_PRESS;
-                    if(conv.y() < 100) checkingGestureDragDown = true;
+                    if(point.position().y() < 100) checkingGestureDragDown = true;
                     break;
                 case QEventPoint::State::Released:
                     packet.inputType = INPUT_TOUCH_RELEASE;
-                    if(conv.y() > 100 && conv.y() < 400 && checkingGestureDragDown) {
+                    // handle the drag down gesture
+                    if(point.position().y() > 100 && point.position().y() < 400 && checkingGestureDragDown) {
                         emit dragDown();
                     }
+                    checkingGestureDragDown = false;
+                    // handle the force-refresh gesture
                     if(lenPoints == 1) {
                         // Last point was released. Free the force-refresh flag.
                         refreshedScreenAlready = false;
                     }
-                    checkingGestureDragDown = false;
                     break;
                 case QEventPoint::State::Updated:
                     packet.inputType = INPUT_TOUCH_UPDATE;
                     break;
                 default: break;
             }
-            qtfb::management::forwardUserInput(framebufferID, &packet);
+            // only forward touch points to the client that started inside the framebuffer area
+            if(image && pressConv.x() > 0 && pressConv.x() < image->width() && pressConv.y() > 0 && pressConv.y() < image->height()) {
+                qtfb::management::forwardUserInput(framebufferID, &packet);
+            }
         }
     }
     me->accept();

--- a/src/qtfb/FBController.h
+++ b/src/qtfb/FBController.h
@@ -95,4 +95,6 @@ private:
     bool refreshedScreenAlready = false;
 
     QImage *image = nullptr;
+
+    void mouseEvent(QMouseEvent *me, int inputType);
 };


### PR DESCRIPTION
For QTFB applications, scaling was duplicated in C++ and QML, resulting in superfluous margins in some configurations. Also Appload now scales windows according to aspectRatio as declared in the manifest instead of the current device aspect ratio.

(also add missing function declaration)